### PR TITLE
fix `AUCMarginLoss` consistency test

### DIFF
--- a/deepblocks/loss/AUCLoss.py
+++ b/deepblocks/loss/AUCLoss.py
@@ -140,7 +140,6 @@ class AUCMarginLoss(_Loss):
         
         self.a = nn.Parameter(torch.randn(1))
         self.b = nn.Parameter(torch.randn(1))
-        self.alpha = nn.Parameter(torch.randn(1))
 
     def forward(self, x, y):
         """ """
@@ -150,7 +149,8 @@ class AUCMarginLoss(_Loss):
         x = torch.sigmoid(x)
 
         # alpha must always be nonnegative
-        p, alpha, a, b, m = self.p, torch.relu(self.alpha), self.a, self.b, self.m
+        p, a, b, m = self.p, self.a, self.b, self.m
+        alpha = torch.relu(1 + b - a)
 
         loss = (1-p)*(x-a).pow(2)*positive
         loss += p*(x-b).pow(2)*negative

--- a/tests/test_auc_margin_loss.py
+++ b/tests/test_auc_margin_loss.py
@@ -6,7 +6,7 @@ def test_consistency():
     # decrease in loss <=> increase in auroc
     x = torch.nn.Parameter(torch.randn(100, 1))
     y = torch.randint(0, 2, size=(100, 1))
-    auc = AUCMarginLoss(p=0.5, m=1)
+    auc = AUCMarginLoss(p=(y==1).float().mean(), m=0.99)
     auroc = AUROC(pos_label=1, compute_on_step=True)
     opt = torch.optim.SGD([x], lr=1)
 


### PR DESCRIPTION
Compute the optimal value of `alpha` maximizing the function directly without gradient ascent.